### PR TITLE
fix: remove `.decode` for 0.13.0

### DIFF
--- a/typst-package/lib.typ
+++ b/typst-package/lib.typ
@@ -1,7 +1,11 @@
 #let spreet = plugin("spreet.wasm")
 
 #let decode(data) = {
-  cbor.decode(spreet.decode(data))
+  if sys.version < version(0, 13, 0) {
+    cbor.decode(spreet.decode(data))
+  } else {
+    cbor(spreet.decode(data))
+  }
 }
 
 #let file-decode(path) = {


### PR DESCRIPTION
`cbor.decode` is deprecated in Typst 0.13.0, so that for version higher than 0.13.0 the function should replace with `cbor` and directly pass the bytes to it. 🎉